### PR TITLE
ftdetect: simplify func name, delete shebang

### DIFF
--- a/ftdetect/rcshell.vim
+++ b/ftdetect/rcshell.vim
@@ -1,10 +1,9 @@
 autocmd BufRead,BufNewFile .rcrc*,rcrc, set filetype=rcshell
 
-function! s:DetectRcShell()
-  let shebang = getline(1)
-  if shebang =~# '\(/\|\s\)rc$'
+function! s:is_rcsh()
+  if getline(1) =~# '\(/\|\s\)rc$'
       set filetype=rcshell
   endif
 endfunction
 
-autocmd BufRead,BufNewFile * call s:DetectRcShell()
+autocmd BufRead,BufNewFile * call s:is_rcsh()


### PR DESCRIPTION
- 'shebang' variable is not widely use
- Snake_case names are often used than CamelCase names:

https://github.com/vim/vim/blob/master/runtime/syntax/sh.vim